### PR TITLE
build: close remaining Plan 2 static-analysis gaps

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,4 +27,6 @@ jobs:
       - name: Build with Gradle
         run: |
           chmod +x ./gradlew
-          ./gradlew build
+          ./gradlew build $LINT_ARGS
+        env:
+          LINT_ARGS: ${{ github.event.pull_request.user.login == 'renovate[bot]' && '-Plint.checkDependencyUpdates=false' || '' }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -126,6 +126,7 @@ dependencies {
     ksp(libs.hilt.compiler)
 
     testImplementation(libs.konsist)
+    testImplementation(libs.kotest.runner.junit5)
     testImplementation(libs.junit.jupiter.api)
     testRuntimeOnly(libs.junit.jupiter.engine)
     testRuntimeOnly(libs.junit.platform.launcher)

--- a/app/src/main/java/de/lemke/oneurl/data/database/Converters.kt
+++ b/app/src/main/java/de/lemke/oneurl/data/database/Converters.kt
@@ -26,6 +26,8 @@ import java.time.format.DateTimeParseException
 
 /** Type converters to map between SQLite types and entity types. */
 object Converters {
+    private const val BITMAP_COMPRESS_QUALITY = 100
+
     /** Returns the string representation of the [zonedDateTime]. */
     @TypeConverter
     fun zonedDateTimeToDb(zonedDateTime: ZonedDateTime?): String = zonedDateTime.toString()
@@ -46,7 +48,7 @@ object Converters {
     @TypeConverter
     fun bitmapToDb(bitmap: Bitmap): ByteArray =
         with(ByteArrayOutputStream()) {
-            bitmap.compress(Bitmap.CompressFormat.PNG, 100, this)
+            bitmap.compress(Bitmap.CompressFormat.PNG, BITMAP_COMPRESS_QUALITY, this)
             return toByteArray()
         }
 

--- a/app/src/main/java/de/lemke/oneurl/domain/CheckURLSafetyUseCase.kt
+++ b/app/src/main/java/de/lemke/oneurl/domain/CheckURLSafetyUseCase.kt
@@ -34,12 +34,6 @@ class CheckURLSafetyUseCase @Inject constructor(
 ) {
     private val tag = "CheckURLSafetyUseCase"
 
-    sealed class UrlhausResult {
-        data object Ok : UrlhausResult()
-
-        data class Blacklisted(val message: String, val urlhausLink: String?, val virustotalLink: String?) : UrlhausResult()
-    }
-
     suspend operator fun invoke(url: String): UrlhausResult =
         suspendCancellableCoroutine { cont ->
             val checkUrlApi = "https://urlhaus-api.abuse.ch/v1/url"
@@ -136,4 +130,10 @@ class CheckURLSafetyUseCase @Inject constructor(
             "abused_redirector" -> context.getString(R.string.error_urlhaus_abused_redirector)
             else -> context.getString(R.string.error_urlhaus_default)
         }
+
+    sealed class UrlhausResult {
+        data object Ok : UrlhausResult()
+
+        data class Blacklisted(val message: String, val urlhausLink: String?, val virustotalLink: String?) : UrlhausResult()
+    }
 }

--- a/app/src/main/java/de/lemke/oneurl/domain/GenerateQRCodeUseCase.kt
+++ b/app/src/main/java/de/lemke/oneurl/domain/GenerateQRCodeUseCase.kt
@@ -87,8 +87,8 @@ class GenerateQRCodeUseCase @Inject constructor(
         val canvas = Canvas(result)
         val paint = Paint()
         paint.color = BLACK
-        paint.alpha = 255
-        paint.textSize = getPixel(16).toFloat()
+        paint.alpha = NO_SUPPORT_TEXT_ALPHA
+        paint.textSize = getPixel(NO_SUPPORT_TEXT_SIZE_DP).toFloat()
         paint.isAntiAlias = true
         val text1 = "QR Codes are not"
         val x1 = (result.width - paint.measureText(text1)) / 2
@@ -154,4 +154,9 @@ class GenerateQRCodeUseCase @Inject constructor(
         } else {
             applyDimension(COMPLEX_UNIT_DIP, dp.toFloat(), context.resources.displayMetrics).toInt()
         }
+
+    companion object {
+        private const val NO_SUPPORT_TEXT_ALPHA = 255
+        private const val NO_SUPPORT_TEXT_SIZE_DP = 16
+    }
 }

--- a/app/src/main/java/de/lemke/oneurl/domain/generateURL/GenerateURLError.kt
+++ b/app/src/main/java/de/lemke/oneurl/domain/generateURL/GenerateURLError.kt
@@ -49,3 +49,20 @@ sealed class GenerateURLError {
 
     data object ServiceOffline : GenerateURLError()
 }
+
+/** HTTP status codes returned by URL-shortener provider APIs, used to map responses to a [GenerateURLError]. */
+object HttpStatusCode {
+    const val OK = 200
+    const val ALREADY_REPORTED = 208
+    const val BAD_REQUEST = 400
+    const val FORBIDDEN = 403
+    const val NOT_FOUND = 404
+    const val LOCKED = 423
+    const val UNPROCESSABLE_ENTITY = 422
+    const val TOO_MANY_REQUESTS = 429
+
+    // Nonstandard (nginx): connection closed with no response.
+    const val NO_RESPONSE = 444
+    const val INTERNAL_SERVER_ERROR = 500
+    const val SERVICE_UNAVAILABLE = 503
+}

--- a/app/src/main/java/de/lemke/oneurl/domain/generateURL/RequestQueueSingleton.kt
+++ b/app/src/main/java/de/lemke/oneurl/domain/generateURL/RequestQueueSingleton.kt
@@ -22,18 +22,6 @@ import com.android.volley.RequestQueue
 import com.android.volley.toolbox.Volley
 
 class RequestQueueSingleton(context: Context) {
-    companion object {
-        @Volatile
-        private var instance: RequestQueueSingleton? = null
-
-        fun getInstance(context: Context) =
-            instance ?: synchronized(this) {
-                instance ?: RequestQueueSingleton(context).also {
-                    instance = it
-                }
-            }
-    }
-
     private val requestQueue: RequestQueue by lazy {
         // applicationContext is key, it keeps you from leaking the
         // Activity or BroadcastReceiver if someone passes one in.
@@ -46,5 +34,17 @@ class RequestQueueSingleton(context: Context) {
 
     fun removeCacheEntry(url: String) {
         requestQueue.cache.remove(url)
+    }
+
+    companion object {
+        @Volatile
+        private var instance: RequestQueueSingleton? = null
+
+        fun getInstance(context: Context) =
+            instance ?: synchronized(this) {
+                instance ?: RequestQueueSingleton(context).also {
+                    instance = it
+                }
+            }
     }
 }

--- a/app/src/main/java/de/lemke/oneurl/domain/model/Dagd.kt
+++ b/app/src/main/java/de/lemke/oneurl/domain/model/Dagd.kt
@@ -25,6 +25,7 @@ import de.lemke.commonutils.ui.utils.urlEncodeAmpersand
 import de.lemke.commonutils.ui.utils.withHttps
 import de.lemke.oneurl.R
 import de.lemke.oneurl.domain.generateURL.GenerateURLError
+import de.lemke.oneurl.domain.generateURL.HttpStatusCode
 import de.lemke.oneurl.domain.generateURL.RequestQueueSingleton
 
 /*
@@ -126,7 +127,7 @@ object Dagd : ShortURLProvider {
                         }
 
                         else -> {
-                            if (statusCode == 404) {
+                            if (statusCode == HttpStatusCode.NOT_FOUND) {
                                 Log.d(tag, "shortURL does not exist yet, creating it")
                             } else {
                                 Log.w(tag, "error, trying to create it anyway")
@@ -169,7 +170,7 @@ object Dagd : ShortURLProvider {
                     successCallback(shortURL)
                 } else {
                     Log.e(tag, "error, response does not start with https://da.gd, response: $response")
-                    errorCallback(GenerateURLError.Unknown(200))
+                    errorCallback(GenerateURLError.Unknown(HttpStatusCode.OK))
                 }
             },
             { error ->

--- a/app/src/main/java/de/lemke/oneurl/domain/model/Gg.kt
+++ b/app/src/main/java/de/lemke/oneurl/domain/model/Gg.kt
@@ -50,6 +50,9 @@ object Gg : ShortURLProvider {
 
             override fun isAliasValid(alias: String) = alias.matches(Regex("[a-zA-Z0-9_-]+"))
         }
+    private const val GG_ERROR_REDIRECT_TO_ROOT = 2001
+    private const val GG_ERROR_ALIAS_MISMATCH = 2002
+    private const val GG_ERROR_UNEXPECTED_RESPONSE = 2009
 
     override fun getInfoContents(context: Context): List<ProviderInfo> =
         listOf(
@@ -141,13 +144,21 @@ object Gg : ShortURLProvider {
                 try {
                     Log.d(tag, "response: $response")
                     when {
-                        response == "$baseURL/" -> errorCallback(GenerateURLError.Unknown(2001))
-                        alias.isNotBlank() && !response.endsWith("/$alias") -> errorCallback(GenerateURLError.Unknown(2002))
-                        else -> successCallback(response)
+                        response == "$baseURL/" -> {
+                            errorCallback(GenerateURLError.Unknown(GG_ERROR_REDIRECT_TO_ROOT))
+                        }
+
+                        alias.isNotBlank() && !response.endsWith("/$alias") -> {
+                            errorCallback(GenerateURLError.Unknown(GG_ERROR_ALIAS_MISMATCH))
+                        }
+
+                        else -> {
+                            successCallback(response)
+                        }
                     }
                 } catch (e: Exception) {
                     Log.e(tag, "error parsing create response", e)
-                    errorCallback(GenerateURLError.Unknown(2009))
+                    errorCallback(GenerateURLError.Unknown(GG_ERROR_UNEXPECTED_RESPONSE))
                 }
             },
             { error ->

--- a/app/src/main/java/de/lemke/oneurl/domain/model/Kurzelinks.kt
+++ b/app/src/main/java/de/lemke/oneurl/domain/model/Kurzelinks.kt
@@ -19,11 +19,13 @@ package de.lemke.oneurl.domain.model
 import android.content.Context
 import android.util.Log
 import com.android.volley.NoConnectionError
+import com.android.volley.VolleyError
 import com.android.volley.toolbox.StringRequest
 import de.lemke.commonutils.ui.utils.withoutHttps
 import de.lemke.oneurl.BuildConfig
 import de.lemke.oneurl.R
 import de.lemke.oneurl.domain.generateURL.GenerateURLError
+import de.lemke.oneurl.domain.generateURL.HttpStatusCode
 import org.json.JSONException
 import org.json.JSONObject
 import de.lemke.commonutils.R as commonutilsR
@@ -107,30 +109,7 @@ sealed class Kurzelinks : ShortURLProvider {
                     errorCallback(GenerateURLError.Unknown())
                 }
             },
-            { error ->
-                // Broad catch is intentional: this runs in a Volley callback on the main thread; an
-                // escaping exception here would crash the whole app.
-                try {
-                    Log.e(tag, "error: $error")
-                    val networkResponse = error.networkResponse
-                    val statusCode = networkResponse?.statusCode
-                    val data = networkResponse?.data?.toString(Charsets.UTF_8)
-                    Log.e(tag, "$statusCode: message: ${error.message} data: $data")
-                    when {
-                        error is NoConnectionError -> errorCallback(GenerateURLError.ServiceOffline)
-                        statusCode == null -> errorCallback(GenerateURLError.Unknown())
-                        data.isNullOrBlank() -> errorCallback(GenerateURLError.Unknown(statusCode))
-                        statusCode == 400 || statusCode == 403 -> errorCallback(GenerateURLError.Unknown(statusCode))
-                        statusCode == 423 -> errorCallback(GenerateURLError.AliasAlreadyExists)
-                        statusCode == 429 -> errorCallback(GenerateURLError.RateLimitExceeded)
-                        statusCode == 444 -> errorCallback(GenerateURLError.ServiceTemporarilyUnavailable(baseURL))
-                        else -> errorCallback(GenerateURLError.Custom(statusCode, data))
-                    }
-                } catch (e: Exception) {
-                    Log.e(tag, "error parsing error response", e)
-                    errorCallback(GenerateURLError.Unknown())
-                }
-            },
+            { error -> handleKurzelinksError(tag, error, errorCallback) },
         ) {
             override fun getParams() =
                 mapOf(
@@ -141,6 +120,59 @@ sealed class Kurzelinks : ShortURLProvider {
                     "servicedomain" to baseURL.withoutHttps(),
                     "requesturl" to alias,
                 )
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun handleKurzelinksError(
+        tag: String,
+        error: VolleyError,
+        errorCallback: (error: GenerateURLError) -> Unit,
+    ) {
+        // Broad catch is intentional: this runs in a Volley callback on the main thread; an
+        // escaping exception here would crash the whole app.
+        try {
+            Log.e(tag, "error: $error")
+            val networkResponse = error.networkResponse
+            val statusCode = networkResponse?.statusCode
+            val data = networkResponse?.data?.toString(Charsets.UTF_8)
+            Log.e(tag, "$statusCode: message: ${error.message} data: $data")
+            when {
+                error is NoConnectionError -> {
+                    errorCallback(GenerateURLError.ServiceOffline)
+                }
+
+                statusCode == null -> {
+                    errorCallback(GenerateURLError.Unknown())
+                }
+
+                data.isNullOrBlank() -> {
+                    errorCallback(GenerateURLError.Unknown(statusCode))
+                }
+
+                statusCode == HttpStatusCode.BAD_REQUEST || statusCode == HttpStatusCode.FORBIDDEN -> {
+                    errorCallback(GenerateURLError.Unknown(statusCode))
+                }
+
+                statusCode == HttpStatusCode.LOCKED -> {
+                    errorCallback(GenerateURLError.AliasAlreadyExists)
+                }
+
+                statusCode == HttpStatusCode.TOO_MANY_REQUESTS -> {
+                    errorCallback(GenerateURLError.RateLimitExceeded)
+                }
+
+                statusCode == HttpStatusCode.NO_RESPONSE -> {
+                    errorCallback(GenerateURLError.ServiceTemporarilyUnavailable(baseURL))
+                }
+
+                else -> {
+                    errorCallback(GenerateURLError.Custom(statusCode, data))
+                }
+            }
+        } catch (e: Exception) {
+            Log.e(tag, "error parsing error response", e)
+            errorCallback(GenerateURLError.Unknown())
         }
     }
 

--- a/app/src/main/java/de/lemke/oneurl/domain/model/L4f.kt
+++ b/app/src/main/java/de/lemke/oneurl/domain/model/L4f.kt
@@ -25,6 +25,7 @@ import com.android.volley.toolbox.JsonObjectRequest
 import de.lemke.commonutils.ui.utils.urlEncodeAmpersand
 import de.lemke.oneurl.R
 import de.lemke.oneurl.domain.generateURL.GenerateURLError
+import de.lemke.oneurl.domain.generateURL.HttpStatusCode
 import org.json.JSONObject
 
 /*
@@ -151,12 +152,12 @@ object L4f : ShortURLProvider {
                 }
 
                 else -> {
-                    errorCallback(GenerateURLError.Custom(200, message))
+                    errorCallback(GenerateURLError.Custom(HttpStatusCode.OK, message))
                 }
             }
         } catch (e: Exception) {
             Log.e(tag, "error parsing response", e)
-            errorCallback(GenerateURLError.Unknown(200))
+            errorCallback(GenerateURLError.Unknown(HttpStatusCode.OK))
         }
     }
 

--- a/app/src/main/java/de/lemke/oneurl/domain/model/Lstu.kt
+++ b/app/src/main/java/de/lemke/oneurl/domain/model/Lstu.kt
@@ -25,6 +25,7 @@ import com.android.volley.toolbox.StringRequest
 import de.lemke.commonutils.ui.utils.withHttps
 import de.lemke.oneurl.R
 import de.lemke.oneurl.domain.generateURL.GenerateURLError
+import de.lemke.oneurl.domain.generateURL.HttpStatusCode
 import de.lemke.oneurl.domain.generateURL.RequestQueueSingleton
 import org.json.JSONException
 import org.json.JSONObject
@@ -78,6 +79,7 @@ object Lstu : ShortURLProvider {
 
             override fun isAliasValid(alias: String) = alias.matches(Regex("[a-zA-Z0-9_-]+"))
         }
+    private const val REQUEST_TIMEOUT_MS = 10000
 
     override fun getInfoContents(context: Context): List<ProviderInfo> =
         listOf(
@@ -160,16 +162,16 @@ object Lstu : ShortURLProvider {
                         }
 
                         json.has("msg") -> {
-                            errorCallback(GenerateURLError.Custom(200, json.getString("msg")))
+                            errorCallback(GenerateURLError.Custom(HttpStatusCode.OK, json.getString("msg")))
                         }
 
                         else -> {
-                            errorCallback(GenerateURLError.Unknown(200))
+                            errorCallback(GenerateURLError.Unknown(HttpStatusCode.OK))
                         }
                     }
                 } catch (e: JSONException) {
                     Log.e(tag, "error parsing create response", e)
-                    errorCallback(GenerateURLError.Unknown(200))
+                    errorCallback(GenerateURLError.Unknown(HttpStatusCode.OK))
                 }
             },
             { error ->
@@ -196,7 +198,7 @@ object Lstu : ShortURLProvider {
 
             override fun getRetryPolicy() =
                 DefaultRetryPolicy(
-                    10000, // set timeout to 10 seconds
+                    REQUEST_TIMEOUT_MS, // set timeout to 10 seconds
                     DefaultRetryPolicy.DEFAULT_MAX_RETRIES,
                     DefaultRetryPolicy.DEFAULT_BACKOFF_MULT,
                 )

--- a/app/src/main/java/de/lemke/oneurl/domain/model/Murl.kt
+++ b/app/src/main/java/de/lemke/oneurl/domain/model/Murl.kt
@@ -26,6 +26,7 @@ import de.lemke.commonutils.ui.utils.urlEncodeAmpersand
 import de.lemke.commonutils.ui.utils.withHttps
 import de.lemke.oneurl.R
 import de.lemke.oneurl.domain.generateURL.GenerateURLError
+import de.lemke.oneurl.domain.generateURL.HttpStatusCode
 import de.lemke.oneurl.domain.generateURL.RequestQueueSingleton
 import de.lemke.commonutils.R as commonutilsR
 
@@ -148,7 +149,7 @@ object Murl : ShortURLProvider {
 
             else -> {
                 Log.e(tag, "error, response does not start with https://murl.com/, response: $response")
-                errorCallback(GenerateURLError.Unknown(200))
+                errorCallback(GenerateURLError.Unknown(HttpStatusCode.OK))
             }
         }
     }
@@ -171,7 +172,7 @@ object Murl : ShortURLProvider {
             when {
                 error is NoConnectionError -> errorCallback(GenerateURLError.ServiceOffline)
                 statusCode == null -> errorCallback(GenerateURLError.Unknown())
-                statusCode == 503 -> errorCallback(GenerateURLError.ServiceTemporarilyUnavailable(baseURL))
+                statusCode == HttpStatusCode.SERVICE_UNAVAILABLE -> errorCallback(GenerateURLError.ServiceTemporarilyUnavailable(baseURL))
                 data.isNullOrBlank() -> errorCallback(GenerateURLError.Unknown(statusCode))
                 data.contains("Long URL cannot be empty", true) -> errorCallback(GenerateURLError.InvalidURL)
                 data.contains("Long URL must have http:// or https://", true) -> errorCallback(GenerateURLError.InvalidURL)

--- a/app/src/main/java/de/lemke/oneurl/domain/model/Oneptco.kt
+++ b/app/src/main/java/de/lemke/oneurl/domain/model/Oneptco.kt
@@ -25,6 +25,7 @@ import com.android.volley.toolbox.JsonObjectRequest
 import de.lemke.commonutils.ui.utils.urlEncodeAmpersand
 import de.lemke.oneurl.R
 import de.lemke.oneurl.domain.generateURL.GenerateURLError
+import de.lemke.oneurl.domain.generateURL.HttpStatusCode
 import org.json.JSONException
 import org.json.JSONObject
 
@@ -62,6 +63,7 @@ object Oneptco : ShortURLProvider {
 
             override fun isAliasValid(alias: String) = alias.matches(Regex("[a-zA-Z0-9_]+"))
         }
+    private const val REQUEST_TIMEOUT_MS = 20000
 
     override fun sanitizeLongURL(url: String) = url.urlEncodeAmpersand().trim()
 
@@ -98,7 +100,7 @@ object Oneptco : ShortURLProvider {
         ) {
             override fun getRetryPolicy() =
                 DefaultRetryPolicy(
-                    20000, // set timeout to 20 seconds
+                    REQUEST_TIMEOUT_MS, // set timeout to 20 seconds
                     DefaultRetryPolicy.DEFAULT_MAX_RETRIES,
                     DefaultRetryPolicy.DEFAULT_BACKOFF_MULT,
                 )
@@ -116,17 +118,17 @@ object Oneptco : ShortURLProvider {
             when {
                 !response.has("message") -> {
                     Log.e(tag, "error: no message")
-                    errorCallback(GenerateURLError.Unknown(200))
+                    errorCallback(GenerateURLError.Unknown(HttpStatusCode.OK))
                 }
 
                 response.getString("message") != "Added!" -> {
                     Log.e(tag, "error: ${response.getString("message")}")
-                    errorCallback(GenerateURLError.Custom(200, response.getString("message")))
+                    errorCallback(GenerateURLError.Custom(HttpStatusCode.OK, response.getString("message")))
                 }
 
                 !response.has("short") -> {
                     Log.e(tag, "error: no short")
-                    errorCallback(GenerateURLError.Unknown(200))
+                    errorCallback(GenerateURLError.Unknown(HttpStatusCode.OK))
                 }
 
                 response.has("receivedRequestedShort") && !response.getBoolean("receivedRequestedShort") -> {
@@ -142,7 +144,7 @@ object Oneptco : ShortURLProvider {
             }
         } catch (e: JSONException) {
             Log.e(tag, "error parsing create response", e)
-            errorCallback(GenerateURLError.Unknown(200))
+            errorCallback(GenerateURLError.Unknown(HttpStatusCode.OK))
         }
     }
 
@@ -164,9 +166,9 @@ object Oneptco : ShortURLProvider {
                 error is NoConnectionError -> errorCallback(GenerateURLError.ServiceOffline)
                 statusCode == null -> errorCallback(GenerateURLError.Unknown())
                 data.isNullOrBlank() -> errorCallback(GenerateURLError.Unknown(statusCode))
-                statusCode == 404 -> errorCallback(GenerateURLError.Unknown(statusCode))
-                statusCode == 500 -> errorCallback(GenerateURLError.InternalServerError)
-                statusCode == 503 -> errorCallback(GenerateURLError.ServiceTemporarilyUnavailable(baseURL))
+                statusCode == HttpStatusCode.NOT_FOUND -> errorCallback(GenerateURLError.Unknown(statusCode))
+                statusCode == HttpStatusCode.INTERNAL_SERVER_ERROR -> errorCallback(GenerateURLError.InternalServerError)
+                statusCode == HttpStatusCode.SERVICE_UNAVAILABLE -> errorCallback(GenerateURLError.ServiceTemporarilyUnavailable(baseURL))
                 else -> errorCallback(GenerateURLError.Custom(statusCode, data))
             }
         } catch (e: Exception) {

--- a/app/src/main/java/de/lemke/oneurl/domain/model/Onesis.kt
+++ b/app/src/main/java/de/lemke/oneurl/domain/model/Onesis.kt
@@ -19,10 +19,12 @@ package de.lemke.oneurl.domain.model
 import android.content.Context
 import android.util.Log
 import com.android.volley.NoConnectionError
+import com.android.volley.VolleyError
 import com.android.volley.toolbox.StringRequest
 import de.lemke.commonutils.ui.utils.withHttps
 import de.lemke.oneurl.R
 import de.lemke.oneurl.domain.generateURL.GenerateURLError
+import de.lemke.oneurl.domain.generateURL.HttpStatusCode
 
 /*
 https://1s.is/
@@ -113,34 +115,40 @@ object Onesis : ShortURLProvider {
                         }
 
                         else -> {
-                            errorCallback(GenerateURLError.Unknown(200))
+                            errorCallback(GenerateURLError.Unknown(HttpStatusCode.OK))
                         }
                     }
                 }
             },
-            { error ->
-                // Broad catch is intentional: this runs in a Volley callback on the main thread; an
-                // escaping exception here would crash the whole app.
-                try {
-                    Log.e(tag, "error: $error")
-                    val message = error.message
-                    val networkResponse = error.networkResponse
-                    val statusCode = networkResponse?.statusCode
-                    val data = networkResponse?.data?.toString(Charsets.UTF_8)
-                    Log.e(tag, "$statusCode: message: $message data: $data")
-                    when {
-                        error is NoConnectionError -> errorCallback(GenerateURLError.ServiceOffline)
-                        statusCode == null -> errorCallback(GenerateURLError.Unknown())
-                        statusCode == 503 -> errorCallback(GenerateURLError.ServiceTemporarilyUnavailable(baseURL))
-                        else -> errorCallback(GenerateURLError.Unknown(statusCode))
-                    }
-                } catch (e: Exception) {
-                    Log.e(tag, "error parsing error response", e)
-                    errorCallback(GenerateURLError.Unknown())
-                }
-            },
+            { error -> handleOnesisError(tag, error, errorCallback) },
         ) {
             override fun getParams() = mapOf("original_url" to longURL, "custom_short_url" to alias)
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun handleOnesisError(
+        tag: String,
+        error: VolleyError,
+        errorCallback: (error: GenerateURLError) -> Unit,
+    ) {
+        // Broad catch is intentional: this runs in a Volley callback on the main thread; an
+        // escaping exception here would crash the whole app.
+        try {
+            Log.e(tag, "error: $error")
+            val networkResponse = error.networkResponse
+            val statusCode = networkResponse?.statusCode
+            val data = networkResponse?.data?.toString(Charsets.UTF_8)
+            Log.e(tag, "$statusCode: message: ${error.message} data: $data")
+            when {
+                error is NoConnectionError -> errorCallback(GenerateURLError.ServiceOffline)
+                statusCode == null -> errorCallback(GenerateURLError.Unknown())
+                statusCode == HttpStatusCode.SERVICE_UNAVAILABLE -> errorCallback(GenerateURLError.ServiceTemporarilyUnavailable(baseURL))
+                else -> errorCallback(GenerateURLError.Unknown(statusCode))
+            }
+        } catch (e: Exception) {
+            Log.e(tag, "error parsing error response", e)
+            errorCallback(GenerateURLError.Unknown())
         }
     }
 }

--- a/app/src/main/java/de/lemke/oneurl/domain/model/Owovc.kt
+++ b/app/src/main/java/de/lemke/oneurl/domain/model/Owovc.kt
@@ -25,6 +25,7 @@ import com.android.volley.toolbox.JsonObjectRequest
 import de.lemke.commonutils.ui.utils.withHttps
 import de.lemke.oneurl.R
 import de.lemke.oneurl.domain.generateURL.GenerateURLError
+import de.lemke.oneurl.domain.generateURL.HttpStatusCode
 import de.lemke.oneurl.domain.generateURL.RequestQueueSingleton
 import org.json.JSONException
 import org.json.JSONObject
@@ -140,7 +141,7 @@ sealed class Owovc : ShortURLProvider {
                     successCallback(shortURL)
                 } else {
                     Log.e(tag, "error: no shortURL in response")
-                    errorCallback(GenerateURLError.Unknown(200))
+                    errorCallback(GenerateURLError.Unknown(HttpStatusCode.OK))
                 }
             },
             { error ->
@@ -153,12 +154,29 @@ sealed class Owovc : ShortURLProvider {
                     val data = networkResponse?.data?.toString(Charsets.UTF_8)
                     Log.e(tag, "$statusCode: message: ${error.message} data: $data")
                     when {
-                        error is NoConnectionError -> errorCallback(GenerateURLError.ServiceOffline)
-                        statusCode == null -> errorCallback(GenerateURLError.Unknown())
-                        statusCode == 503 -> errorCallback(GenerateURLError.ServiceTemporarilyUnavailable(baseURL))
-                        data.isNullOrBlank() -> errorCallback(GenerateURLError.Unknown(statusCode))
-                        statusCode == 400 && data.contains("link must match pattern") -> errorCallback(GenerateURLError.InvalidURL)
-                        else -> errorCallback(GenerateURLError.Custom(statusCode, data))
+                        error is NoConnectionError -> {
+                            errorCallback(GenerateURLError.ServiceOffline)
+                        }
+
+                        statusCode == null -> {
+                            errorCallback(GenerateURLError.Unknown())
+                        }
+
+                        statusCode == HttpStatusCode.SERVICE_UNAVAILABLE -> {
+                            errorCallback(GenerateURLError.ServiceTemporarilyUnavailable(baseURL))
+                        }
+
+                        data.isNullOrBlank() -> {
+                            errorCallback(GenerateURLError.Unknown(statusCode))
+                        }
+
+                        statusCode == HttpStatusCode.BAD_REQUEST && data.contains("link must match pattern") -> {
+                            errorCallback(GenerateURLError.InvalidURL)
+                        }
+
+                        else -> {
+                            errorCallback(GenerateURLError.Custom(statusCode, data))
+                        }
                     }
                 } catch (e: Exception) {
                     Log.e(tag, "error parsing error response", e)

--- a/app/src/main/java/de/lemke/oneurl/domain/model/Shareaholic.kt
+++ b/app/src/main/java/de/lemke/oneurl/domain/model/Shareaholic.kt
@@ -57,6 +57,9 @@ object Shareaholic : ShortURLProvider {
     override val apiURL = "$baseURL/v2/share/shorten_link"
     override val privacyURL = "$baseURL/privacy"
     override val termsURL = "$baseURL/terms"
+    private const val SHAREAHOLIC_ERROR_MISSING_API_KEY = 1100
+    private const val SHAREAHOLIC_ERROR_INVALID_API_KEY = 1101
+    private const val SHAREAHOLIC_ERROR_MISSING_URL = 1140
 
     override fun sanitizeLongURL(url: String) = url.urlEncodeAmpersand().trim()
 
@@ -145,17 +148,17 @@ object Shareaholic : ShortURLProvider {
         Log.e(tag, "first error: $firstError")
         when (firstError?.optString("code")) {
             "100" -> {
-                errorCallback(GenerateURLError.Unknown(1100))
+                errorCallback(GenerateURLError.Unknown(SHAREAHOLIC_ERROR_MISSING_API_KEY))
             }
 
             // 100	apikey not provided
             "101" -> {
-                errorCallback(GenerateURLError.Unknown(1101))
+                errorCallback(GenerateURLError.Unknown(SHAREAHOLIC_ERROR_INVALID_API_KEY))
             }
 
             // 101	apikey provided is invalid
             "140" -> {
-                errorCallback(GenerateURLError.Unknown(1140))
+                errorCallback(GenerateURLError.Unknown(SHAREAHOLIC_ERROR_MISSING_URL))
             }
 
             // 140	Missing URL

--- a/app/src/main/java/de/lemke/oneurl/domain/model/ShortURLProvider.kt
+++ b/app/src/main/java/de/lemke/oneurl/domain/model/ShortURLProvider.kt
@@ -214,13 +214,13 @@ class ProviderInfo(
 )
 
 interface AliasConfig {
-    companion object {
-        const val NO_MAX_ALIAS_SPECIFIED = 100
-    }
-
     val minAliasLength: Int
     val maxAliasLength: Int
     val allowedAliasCharacters: String
 
     fun isAliasValid(alias: String): Boolean
+
+    companion object {
+        const val NO_MAX_ALIAS_SPECIFIED = 100
+    }
 }

--- a/app/src/main/java/de/lemke/oneurl/domain/model/Shorturlat.kt
+++ b/app/src/main/java/de/lemke/oneurl/domain/model/Shorturlat.kt
@@ -23,6 +23,7 @@ import com.android.volley.Request
 import com.android.volley.toolbox.StringRequest
 import de.lemke.oneurl.R
 import de.lemke.oneurl.domain.generateURL.GenerateURLError
+import de.lemke.oneurl.domain.generateURL.HttpStatusCode
 import de.lemke.oneurl.domain.generateURL.RequestQueueSingleton
 import de.lemke.commonutils.R as commonutilsR
 
@@ -190,7 +191,7 @@ object Shorturlat : ShortURLProvider {
                     successCallback(shortURL)
                 } else {
                     Log.e(tag, "error parsing create response")
-                    errorCallback(GenerateURLError.Unknown(200))
+                    errorCallback(GenerateURLError.Unknown(HttpStatusCode.OK))
                 }
             },
             { error ->

--- a/app/src/main/java/de/lemke/oneurl/domain/model/Spoome.kt
+++ b/app/src/main/java/de/lemke/oneurl/domain/model/Spoome.kt
@@ -26,6 +26,7 @@ import de.lemke.commonutils.ui.utils.urlEncodeAmpersand
 import de.lemke.commonutils.ui.utils.withHttps
 import de.lemke.oneurl.R
 import de.lemke.oneurl.domain.generateURL.GenerateURLError
+import de.lemke.oneurl.domain.generateURL.HttpStatusCode
 import de.lemke.oneurl.domain.generateURL.RequestQueueSingleton
 import org.json.JSONException
 import org.json.JSONObject
@@ -158,7 +159,7 @@ sealed class Spoome : ShortURLProvider {
             successCallback(shortURL)
         } else {
             Log.e(tag, "error: response does not contain short_url")
-            errorCallback(GenerateURLError.Unknown(200))
+            errorCallback(GenerateURLError.Unknown(HttpStatusCode.OK))
         }
     }
 
@@ -199,7 +200,7 @@ sealed class Spoome : ShortURLProvider {
                     handleEmojiError(response.getString("EmojiError"), statusCode, errorCallback)
                 }
 
-                statusCode == 429 -> {
+                statusCode == HttpStatusCode.TOO_MANY_REQUESTS -> {
                     errorCallback(GenerateURLError.RateLimitExceeded)
                 }
 

--- a/app/src/main/java/de/lemke/oneurl/domain/model/Tinube.kt
+++ b/app/src/main/java/de/lemke/oneurl/domain/model/Tinube.kt
@@ -25,6 +25,7 @@ import de.lemke.commonutils.ui.utils.urlEncodeAmpersand
 import de.lemke.commonutils.ui.utils.withHttps
 import de.lemke.oneurl.R
 import de.lemke.oneurl.domain.generateURL.GenerateURLError
+import de.lemke.oneurl.domain.generateURL.HttpStatusCode
 import de.lemke.oneurl.domain.generateURL.RequestQueueSingleton
 import org.json.JSONException
 import org.json.JSONObject
@@ -154,10 +155,10 @@ object Tinube : ShortURLProvider {
                     }
                 Log.d(tag, "status: $status, urlCode: $urlCode")
                 when {
-                    status == 200 && urlCode != null -> successCallback("$baseURL/$urlCode")
-                    status == 208 -> errorCallback(GenerateURLError.AliasAlreadyExists)
+                    status == HttpStatusCode.OK && urlCode != null -> successCallback("$baseURL/$urlCode")
+                    status == HttpStatusCode.ALREADY_REPORTED -> errorCallback(GenerateURLError.AliasAlreadyExists)
                     status != null -> errorCallback(GenerateURLError.Unknown(status))
-                    else -> errorCallback(GenerateURLError.Unknown(200))
+                    else -> errorCallback(GenerateURLError.Unknown(HttpStatusCode.OK))
                 }
             },
             { error ->

--- a/app/src/main/java/de/lemke/oneurl/domain/model/Tinube.kt
+++ b/app/src/main/java/de/lemke/oneurl/domain/model/Tinube.kt
@@ -144,7 +144,7 @@ object Tinube : ShortURLProvider {
                         ?.getOrNull(1)
                         ?.toIntOrNull()
                 val urlCode =
-                    if (status == 200) {
+                    if (status == HttpStatusCode.OK) {
                         data
                             .split("urlCode\":\"")
                             .getOrNull(1)

--- a/app/src/main/java/de/lemke/oneurl/domain/model/Tinyurl.kt
+++ b/app/src/main/java/de/lemke/oneurl/domain/model/Tinyurl.kt
@@ -24,6 +24,7 @@ import com.android.volley.toolbox.StringRequest
 import de.lemke.commonutils.ui.utils.urlEncodeAmpersand
 import de.lemke.oneurl.R
 import de.lemke.oneurl.domain.generateURL.GenerateURLError
+import de.lemke.oneurl.domain.generateURL.HttpStatusCode
 
 /*
 https://tinyurl.com/app
@@ -85,7 +86,7 @@ object Tinyurl : ShortURLProvider {
                     successCallback(shortURL)
                 } else {
                     Log.e(tag, "error, response does not start with http(s)://tinyurl.com/, response: $response")
-                    errorCallback(GenerateURLError.Custom(200, response))
+                    errorCallback(GenerateURLError.Custom(HttpStatusCode.OK, response))
                 }
             },
             { error ->
@@ -110,7 +111,7 @@ object Tinyurl : ShortURLProvider {
                             errorCallback(GenerateURLError.Unknown(statusCode))
                         }
 
-                        statusCode == 422 || statusCode == 400 -> {
+                        statusCode == HttpStatusCode.UNPROCESSABLE_ENTITY || statusCode == HttpStatusCode.BAD_REQUEST -> {
                             if (alias.isBlank()) {
                                 errorCallback(GenerateURLError.InvalidURL)
                             } else {

--- a/app/src/main/java/de/lemke/oneurl/domain/model/Tly.kt
+++ b/app/src/main/java/de/lemke/oneurl/domain/model/Tly.kt
@@ -19,9 +19,11 @@ package de.lemke.oneurl.domain.model
 import android.content.Context
 import android.util.Log
 import com.android.volley.NoConnectionError
+import com.android.volley.VolleyError
 import com.android.volley.toolbox.JsonObjectRequest
 import de.lemke.oneurl.R
 import de.lemke.oneurl.domain.generateURL.GenerateURLError
+import de.lemke.oneurl.domain.generateURL.HttpStatusCode
 import org.json.JSONObject
 import de.lemke.commonutils.R as commonutilsR
 
@@ -129,34 +131,10 @@ sealed class Tly : ShortURLProvider {
                     successCallback(shortURL)
                 } else {
                     Log.e(tag, "error: no shortURL in response")
-                    errorCallback(GenerateURLError.Unknown(200))
+                    errorCallback(GenerateURLError.Unknown(HttpStatusCode.OK))
                 }
             },
-            { error ->
-                // Broad catch is intentional: this runs in a Volley callback on the main thread; an
-                // escaping exception here would crash the whole app.
-                try {
-                    Log.e(tag, "error: $error")
-                    val networkResponse = error.networkResponse
-                    val statusCode = networkResponse?.statusCode
-                    val data = networkResponse?.data?.toString(Charsets.UTF_8)
-                    val message = data?.takeIf { it.isNotBlank() }?.let { runCatching { JSONObject(it).optString("message") }.getOrNull() }
-                    Log.e(tag, "$statusCode: message: ${error.message} data: $data")
-                    Log.e(tag, "response message: $message")
-                    when {
-                        error is NoConnectionError -> errorCallback(GenerateURLError.ServiceOffline)
-                        statusCode == null -> errorCallback(GenerateURLError.Unknown())
-                        statusCode == 503 -> errorCallback(GenerateURLError.ServiceTemporarilyUnavailable(baseURL))
-                        data.isNullOrBlank() || message.isNullOrBlank() -> errorCallback(GenerateURLError.Unknown(statusCode))
-                        message.contains("long url field is required", true) -> errorCallback(GenerateURLError.InvalidURL)
-                        message.contains("T.LY account and API key", true) -> errorCallback(GenerateURLError.RateLimitExceeded)
-                        else -> errorCallback(GenerateURLError.Custom(statusCode, message))
-                    }
-                } catch (e: Exception) {
-                    Log.e(tag, "error parsing error response", e)
-                    errorCallback(GenerateURLError.Unknown())
-                }
-            },
+            { error -> handleTlyError(tag, error, errorCallback) },
         ) {
             override fun getHeaders() =
                 mapOf(
@@ -164,6 +142,37 @@ sealed class Tly : ShortURLProvider {
                     "content-type" to "application/json;charset=UTF-8",
                     "origin" to "chrome-extension://oodfdmglhbbkkcngodjjagblikmoegpa",
                 )
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun handleTlyError(
+        tag: String,
+        error: VolleyError,
+        errorCallback: (error: GenerateURLError) -> Unit,
+    ) {
+        // Broad catch is intentional: this runs in a Volley callback on the main thread; an
+        // escaping exception here would crash the whole app.
+        try {
+            Log.e(tag, "error: $error")
+            val networkResponse = error.networkResponse
+            val statusCode = networkResponse?.statusCode
+            val data = networkResponse?.data?.toString(Charsets.UTF_8)
+            val message = data?.takeIf { it.isNotBlank() }?.let { runCatching { JSONObject(it).optString("message") }.getOrNull() }
+            Log.e(tag, "$statusCode: message: ${error.message} data: $data")
+            Log.e(tag, "response message: $message")
+            when {
+                error is NoConnectionError -> errorCallback(GenerateURLError.ServiceOffline)
+                statusCode == null -> errorCallback(GenerateURLError.Unknown())
+                statusCode == HttpStatusCode.SERVICE_UNAVAILABLE -> errorCallback(GenerateURLError.ServiceTemporarilyUnavailable(baseURL))
+                data.isNullOrBlank() || message.isNullOrBlank() -> errorCallback(GenerateURLError.Unknown(statusCode))
+                message.contains("long url field is required", true) -> errorCallback(GenerateURLError.InvalidURL)
+                message.contains("T.LY account and API key", true) -> errorCallback(GenerateURLError.RateLimitExceeded)
+                else -> errorCallback(GenerateURLError.Custom(statusCode, message))
+            }
+        } catch (e: Exception) {
+            Log.e(tag, "error parsing error response", e)
+            errorCallback(GenerateURLError.Unknown())
         }
     }
 

--- a/app/src/main/java/de/lemke/oneurl/domain/model/Tnyim.kt
+++ b/app/src/main/java/de/lemke/oneurl/domain/model/Tnyim.kt
@@ -26,6 +26,7 @@ import com.android.volley.toolbox.StringRequest
 import de.lemke.commonutils.ui.utils.urlEncodeAmpersand
 import de.lemke.oneurl.R
 import de.lemke.oneurl.domain.generateURL.GenerateURLError
+import de.lemke.oneurl.domain.generateURL.HttpStatusCode
 import de.lemke.oneurl.domain.generateURL.RequestQueueSingleton
 import org.json.JSONException
 import org.json.JSONObject
@@ -129,6 +130,7 @@ object Tnyim : ShortURLProvider {
 
             override fun isAliasValid(alias: String) = alias.matches(Regex("[a-zA-Z0-9-]+"))
         }
+    private const val REQUEST_TIMEOUT_MS = 10000
 
     override fun getInfoContents(context: Context): List<ProviderInfo> =
         listOf(
@@ -214,7 +216,7 @@ object Tnyim : ShortURLProvider {
                         }
                     } else {
                         Log.d(tag, "error: response does not contain short url or errors")
-                        errorCallback(GenerateURLError.Unknown(200))
+                        errorCallback(GenerateURLError.Unknown(HttpStatusCode.OK))
                     }
                 } catch (e: JSONException) {
                     Log.e(tag, "error parsing create response", e)
@@ -234,7 +236,7 @@ object Tnyim : ShortURLProvider {
                         error is NoConnectionError -> errorCallback(GenerateURLError.ServiceOffline)
                         statusCode == null -> errorCallback(GenerateURLError.Unknown())
                         data.isNullOrBlank() -> errorCallback(GenerateURLError.Unknown(statusCode))
-                        statusCode == 500 -> errorCallback(GenerateURLError.Unknown(statusCode))
+                        statusCode == HttpStatusCode.INTERNAL_SERVER_ERROR -> errorCallback(GenerateURLError.Unknown(statusCode))
                         else -> errorCallback(GenerateURLError.Custom(statusCode, data))
                     }
                 } catch (e: Exception) {
@@ -245,7 +247,7 @@ object Tnyim : ShortURLProvider {
         ) {
             override fun getRetryPolicy() =
                 DefaultRetryPolicy(
-                    10000, // set timeout to 10 seconds
+                    REQUEST_TIMEOUT_MS, // set timeout to 10 seconds
                     DefaultRetryPolicy.DEFAULT_MAX_RETRIES,
                     DefaultRetryPolicy.DEFAULT_BACKOFF_MULT,
                 )

--- a/app/src/main/java/de/lemke/oneurl/domain/model/URL.kt
+++ b/app/src/main/java/de/lemke/oneurl/domain/model/URL.kt
@@ -32,6 +32,13 @@ data class URL(
     val description: String,
     val added: ZonedDateTime,
 ) {
+    val id: Long get() = shortURL.hashCode().toLong()
+
+    val alias: String
+        get() = shortURL.trimEnd('/').substringAfterLast('/').substringBeforeLast('/') // does not work for Owovc(e.g. sketchy)
+
+    val addedFormatMedium: String get() = added.format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM))
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
@@ -55,13 +62,6 @@ data class URL(
         result = 31 * result + added.hashCode()
         return result
     }
-
-    val id: Long get() = shortURL.hashCode().toLong()
-
-    val alias: String
-        get() = shortURL.trimEnd('/').substringAfterLast('/').substringBeforeLast('/') // does not work for Owovc(e.g. sketchy)
-
-    val addedFormatMedium: String get() = added.format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM))
 
     fun contains(query: String): Boolean = contains(StringTokenizer(query))
 

--- a/app/src/main/java/de/lemke/oneurl/domain/model/Ulvis.kt
+++ b/app/src/main/java/de/lemke/oneurl/domain/model/Ulvis.kt
@@ -26,6 +26,7 @@ import de.lemke.commonutils.ui.utils.urlEncodeAmpersand
 import de.lemke.commonutils.ui.utils.withHttps
 import de.lemke.oneurl.R
 import de.lemke.oneurl.domain.generateURL.GenerateURLError
+import de.lemke.oneurl.domain.generateURL.HttpStatusCode
 import de.lemke.oneurl.domain.generateURL.RequestQueueSingleton
 import org.json.JSONException
 import org.json.JSONObject
@@ -203,17 +204,17 @@ object Ulvis : ShortURLProvider {
                         code == 1 -> errorCallback(GenerateURLError.InvalidURL)
                         code == 2 -> errorCallback(GenerateURLError.InvalidAlias)
                         error.has("msg") -> errorCallback(GenerateURLError.Custom(code, error.optString("msg")))
-                        else -> errorCallback(GenerateURLError.Unknown(200))
+                        else -> errorCallback(GenerateURLError.Unknown(HttpStatusCode.OK))
                     }
                 }
 
                 else -> {
-                    errorCallback(GenerateURLError.Unknown(200))
+                    errorCallback(GenerateURLError.Unknown(HttpStatusCode.OK))
                 }
             }
         } catch (e: JSONException) {
             Log.e(tag, "error parsing create response", e)
-            errorCallback(GenerateURLError.Unknown(200))
+            errorCallback(GenerateURLError.Unknown(HttpStatusCode.OK))
         }
     }
 
@@ -234,7 +235,7 @@ object Ulvis : ShortURLProvider {
             when {
                 error is NoConnectionError -> errorCallback(GenerateURLError.ServiceOffline)
                 statusCode == null -> errorCallback(GenerateURLError.Unknown())
-                statusCode == 403 -> errorCallback(GenerateURLError.ServiceTemporarilyUnavailable(baseURL))
+                statusCode == HttpStatusCode.FORBIDDEN -> errorCallback(GenerateURLError.ServiceTemporarilyUnavailable(baseURL))
                 data.isNullOrBlank() -> errorCallback(GenerateURLError.Unknown(statusCode))
                 else -> errorCallback(GenerateURLError.Custom(statusCode, data))
             }

--- a/app/src/main/java/de/lemke/oneurl/domain/model/VgdIsgd.kt
+++ b/app/src/main/java/de/lemke/oneurl/domain/model/VgdIsgd.kt
@@ -25,6 +25,7 @@ import com.android.volley.toolbox.JsonObjectRequest
 import de.lemke.commonutils.ui.utils.urlEncodeAmpersand
 import de.lemke.oneurl.R
 import de.lemke.oneurl.domain.generateURL.GenerateURLError
+import de.lemke.oneurl.domain.generateURL.HttpStatusCode
 import org.json.JSONObject
 import de.lemke.commonutils.R as commonutilsR
 
@@ -117,7 +118,7 @@ sealed class VgdIsgd : ShortURLProvider {
                 else -> {
                     errorCallback(
                         GenerateURLError.Custom(
-                            200,
+                            HttpStatusCode.OK,
                             response.optString("errormessage") + " (${response.getString("errorcode")})",
                         ),
                     )
@@ -127,7 +128,7 @@ sealed class VgdIsgd : ShortURLProvider {
         }
         if (!response.has("shorturl")) {
             Log.e(tag, "error, response does not contain shorturl, response: $response")
-            errorCallback(GenerateURLError.Unknown(200))
+            errorCallback(GenerateURLError.Unknown(HttpStatusCode.OK))
             return
         }
         val shortURL = response.getString("shorturl").trim()

--- a/app/src/main/java/de/lemke/oneurl/domain/model/Zwsim.kt
+++ b/app/src/main/java/de/lemke/oneurl/domain/model/Zwsim.kt
@@ -24,6 +24,7 @@ import com.android.volley.toolbox.JsonObjectRequest
 import de.lemke.commonutils.ui.utils.withHttps
 import de.lemke.oneurl.R
 import de.lemke.oneurl.domain.generateURL.GenerateURLError
+import de.lemke.oneurl.domain.generateURL.HttpStatusCode
 import org.json.JSONObject
 import de.lemke.commonutils.R as commonutilsR
 
@@ -93,7 +94,7 @@ object Zwsim : ShortURLProvider {
 
                     else -> {
                         Log.e(tag, "error, response does not contain short url")
-                        errorCallback(GenerateURLError.Unknown(200))
+                        errorCallback(GenerateURLError.Unknown(HttpStatusCode.OK))
                     }
                 }
             },
@@ -108,12 +109,29 @@ object Zwsim : ShortURLProvider {
                     val data = networkResponse?.data?.toString(Charsets.UTF_8)
                     Log.e(tag, "$statusCode: message: $message data: $data")
                     when {
-                        error is NoConnectionError -> errorCallback(GenerateURLError.ServiceOffline)
-                        statusCode == null -> errorCallback(GenerateURLError.Unknown())
-                        data.isNullOrBlank() -> errorCallback(GenerateURLError.Unknown(statusCode))
-                        statusCode == 422 && data.contains("Invalid url") -> errorCallback(GenerateURLError.InvalidURL)
-                        statusCode == 503 -> errorCallback(GenerateURLError.ServiceTemporarilyUnavailable(baseURL))
-                        else -> errorCallback(GenerateURLError.Custom(statusCode, data))
+                        error is NoConnectionError -> {
+                            errorCallback(GenerateURLError.ServiceOffline)
+                        }
+
+                        statusCode == null -> {
+                            errorCallback(GenerateURLError.Unknown())
+                        }
+
+                        data.isNullOrBlank() -> {
+                            errorCallback(GenerateURLError.Unknown(statusCode))
+                        }
+
+                        statusCode == HttpStatusCode.UNPROCESSABLE_ENTITY && data.contains("Invalid url") -> {
+                            errorCallback(GenerateURLError.InvalidURL)
+                        }
+
+                        statusCode == HttpStatusCode.SERVICE_UNAVAILABLE -> {
+                            errorCallback(GenerateURLError.ServiceTemporarilyUnavailable(baseURL))
+                        }
+
+                        else -> {
+                            errorCallback(GenerateURLError.Custom(statusCode, data))
+                        }
                     }
                 } catch (e: Exception) {
                     Log.e(tag, "error parsing error response", e)

--- a/app/src/main/java/de/lemke/oneurl/ui/AddURLActivity.kt
+++ b/app/src/main/java/de/lemke/oneurl/ui/AddURLActivity.kt
@@ -156,7 +156,7 @@ class AddURLActivity : AppCompatActivity() {
     }
 
     private fun initFooterButton() {
-        if (resources.configuration.screenWidthDp < 360) {
+        if (resources.configuration.screenWidthDp < COMPACT_SCREEN_WIDTH_DP) {
             binding.addUrlFooterButton.layoutParams.width = MATCH_PARENT
         }
         binding.addUrlFooterButton.setOnClickListener { submit() }
@@ -297,5 +297,9 @@ class AddURLActivity : AppCompatActivity() {
                 getString(commonutilsR.string.commonutils_error_unknown)
             },
         )
+    }
+
+    companion object {
+        private const val COMPACT_SCREEN_WIDTH_DP = 360
     }
 }

--- a/app/src/main/java/de/lemke/oneurl/ui/GenerateQRCodeActivity.kt
+++ b/app/src/main/java/de/lemke/oneurl/ui/GenerateQRCodeActivity.kt
@@ -105,7 +105,7 @@ class GenerateQRCodeActivity : AppCompatActivity(), ViewYTranslator by AppBarAwa
             if (!isInitialized) {
                 isInitialized = true
                 initControls(state)
-                setCustomBackAnimation(binding.root, showInAppReviewIfPossible = true)
+                setCustomBackAnimation(binding.root, inAppReview = settings)
                 binding.qrCode.translateYWithAppBar(binding.toolbarLayout.appBarLayout, this@GenerateQRCodeActivity)
             }
         }

--- a/app/src/main/java/de/lemke/oneurl/ui/MainActivity.kt
+++ b/app/src/main/java/de/lemke/oneurl/ui/MainActivity.kt
@@ -129,6 +129,42 @@ class MainActivity :
         )
     }
 
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        if (intent.action == ACTION_SEARCH) binding.drawerLayout.setSearchQueryFromIntent(intent)
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu?): Boolean = menuInflater.inflate(R.menu.main, menu).let { true }
+
+    override fun onPrepareOptionsMenu(menu: Menu?): Boolean {
+        menu?.findItem(R.id.menu_item_show_all)?.isVisible = viewModel.filterFavorite.value
+        menu?.findItem(R.id.menu_item_only_show_favorites)?.isVisible = !viewModel.filterFavorite.value
+        return super.onPrepareOptionsMenu(menu)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean =
+        when (item.itemId) {
+            R.id.menu_item_search -> {
+                startSearch().let { true }
+            }
+
+            R.id.menu_item_show_all -> {
+                viewModel.setFilterFavorite(false)
+                invalidateOptionsMenu()
+                true
+            }
+
+            R.id.menu_item_only_show_favorites -> {
+                viewModel.setFilterFavorite(true)
+                invalidateOptionsMenu()
+                true
+            }
+
+            else -> {
+                super.onOptionsItemSelected(item)
+            }
+        }
+
     private fun openMain(savedInstanceState: Bundle?) {
         setupCommonUtilsAboutActivity(appVersion = BuildConfig.VERSION_NAME)
         setupCommonUtilsSettingsActivity(
@@ -176,42 +212,6 @@ class MainActivity :
             )
         }
     }
-
-    override fun onNewIntent(intent: Intent) {
-        super.onNewIntent(intent)
-        if (intent.action == ACTION_SEARCH) binding.drawerLayout.setSearchQueryFromIntent(intent)
-    }
-
-    override fun onCreateOptionsMenu(menu: Menu?): Boolean = menuInflater.inflate(R.menu.main, menu).let { true }
-
-    override fun onPrepareOptionsMenu(menu: Menu?): Boolean {
-        menu?.findItem(R.id.menu_item_show_all)?.isVisible = viewModel.filterFavorite.value
-        menu?.findItem(R.id.menu_item_only_show_favorites)?.isVisible = !viewModel.filterFavorite.value
-        return super.onPrepareOptionsMenu(menu)
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean =
-        when (item.itemId) {
-            R.id.menu_item_search -> {
-                startSearch().let { true }
-            }
-
-            R.id.menu_item_show_all -> {
-                viewModel.setFilterFavorite(false)
-                invalidateOptionsMenu()
-                true
-            }
-
-            R.id.menu_item_only_show_favorites -> {
-                viewModel.setFilterFavorite(true)
-                invalidateOptionsMenu()
-                true
-            }
-
-            else -> {
-                super.onOptionsItemSelected(item)
-            }
-        }
 
     private fun startSearch() =
         binding.drawerLayout.startSearchMode(

--- a/app/src/main/java/de/lemke/oneurl/ui/MainActivity.kt
+++ b/app/src/main/java/de/lemke/oneurl/ui/MainActivity.kt
@@ -112,7 +112,7 @@ class MainActivity :
             allowSkip = BuildConfig.FIRST_RUN_SKIPPABLE,
         ) ?: return
         prepareActivityTransformationFrom()
-        if (SDK_INT >= 34) overrideActivityTransition(OVERRIDE_TRANSITION_OPEN, fade_in, fade_out)
+        if (SDK_INT >= VERSION_CODES.UPSIDE_DOWN_CAKE) overrideActivityTransition(OVERRIDE_TRANSITION_OPEN, fade_in, fade_out)
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
         configureCommonUtilsSplashScreen(splashScreen, binding.root) { !viewModel.state.value.isUIReady }

--- a/app/src/main/java/de/lemke/oneurl/ui/ProviderActivity.kt
+++ b/app/src/main/java/de/lemke/oneurl/ui/ProviderActivity.kt
@@ -44,10 +44,6 @@ import dev.oneuiproject.oneui.utils.SemItemDecoration
 
 @AndroidEntryPoint
 class ProviderActivity : AppCompatActivity() {
-    companion object {
-        const val KEY_SELECT_PROVIDER = "key_select_provider"
-    }
-
     private lateinit var binding: ActivityProviderBinding
     private val viewModel: ProviderViewModel by viewModels()
     private val providerAdapter = ProviderAdapter()
@@ -87,13 +83,12 @@ class ProviderActivity : AppCompatActivity() {
         }
     }
 
+    companion object {
+        const val KEY_SELECT_PROVIDER = "key_select_provider"
+    }
+
     inner class ProviderAdapter : RecyclerView.Adapter<ProviderAdapter.ViewHolder>() {
         private var providers: List<ShortURLProvider> = emptyList()
-
-        fun updateProviders(newProviders: List<ShortURLProvider>) {
-            providers = newProviders
-            notifyDataSetChanged()
-        }
 
         override fun getItemCount(): Int = providers.size
 
@@ -122,6 +117,11 @@ class ProviderActivity : AppCompatActivity() {
             holder.parentView.setOnClickListener { viewModel.onProviderClick(provider) }
             holder.iconLayout.setOnClickListener { viewModel.onProviderInfoClick(provider) }
             holder.parentView.setOnLongClickListener { viewModel.onProviderInfoClick(provider).let { true } }
+        }
+
+        fun updateProviders(newProviders: List<ShortURLProvider>) {
+            providers = newProviders
+            notifyDataSetChanged()
         }
 
         inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {

--- a/app/src/main/java/de/lemke/oneurl/ui/ProviderInfoBottomSheet.kt
+++ b/app/src/main/java/de/lemke/oneurl/ui/ProviderInfoBottomSheet.kt
@@ -77,7 +77,7 @@ class ProviderInfoBottomSheet : SemBottomSheetDialogFragment() {
             0 -> binding.providerBottomSheetInfo1 to binding.providerBottomSheetInfoText1
             1 -> binding.providerBottomSheetInfo2 to binding.providerBottomSheetInfoText2
             2 -> binding.providerBottomSheetInfo3 to binding.providerBottomSheetInfoText3
-            3 -> binding.providerBottomSheetInfo4 to binding.providerBottomSheetInfoText4
+            LAST_INFO_CONTENT_INDEX -> binding.providerBottomSheetInfo4 to binding.providerBottomSheetInfoText4
             else -> null
         }
 
@@ -131,5 +131,6 @@ class ProviderInfoBottomSheet : SemBottomSheetDialogFragment() {
             }
 
         const val KEY_PROVIDER = "key_provider"
+        private const val LAST_INFO_CONTENT_INDEX = 3
     }
 }

--- a/app/src/main/java/de/lemke/oneurl/ui/ProviderInfoBottomSheet.kt
+++ b/app/src/main/java/de/lemke/oneurl/ui/ProviderInfoBottomSheet.kt
@@ -52,10 +52,6 @@ class ProviderInfoBottomSheet : SemBottomSheetDialogFragment() {
         savedInstanceState: Bundle?,
     ): View = ViewProviderInfoBottomsheetBinding.inflate(inflater, container, false).also { binding = it }.root
 
-    private fun AppCompatButton.setIcon(icon: Int) {
-        setCompoundDrawablesRelativeWithIntrinsicBounds(getDrawable(requireContext(), icon), null, null, null)
-    }
-
     override fun onViewCreated(
         view: View,
         savedInstanceState: Bundle?,
@@ -70,6 +66,10 @@ class ProviderInfoBottomSheet : SemBottomSheetDialogFragment() {
         }
         bindInfoContents(provider)
         bindInfoButtons(provider)
+    }
+
+    private fun AppCompatButton.setIcon(icon: Int) {
+        setCompoundDrawablesRelativeWithIntrinsicBounds(getDrawable(requireContext(), icon), null, null, null)
     }
 
     private fun infoContentViewsAt(index: Int): Pair<AppCompatButton, TextView>? =

--- a/app/src/main/java/de/lemke/oneurl/ui/QRBottomSheet.kt
+++ b/app/src/main/java/de/lemke/oneurl/ui/QRBottomSheet.kt
@@ -105,10 +105,12 @@ class QRBottomSheet : SemBottomSheetDialogFragment() {
     }
 }
 
+private const val BITMAP_COMPRESS_QUALITY = 100
+
 // java.lang.RuntimeException: Could not copy bitmap to parcel blob. ???????
 private fun Bitmap.toByteArray(): ByteArray =
     ByteArrayOutputStream().use { stream ->
-        compress(Bitmap.CompressFormat.PNG, 100, stream)
+        compress(Bitmap.CompressFormat.PNG, BITMAP_COMPRESS_QUALITY, stream)
         stream.toByteArray()
     }
 

--- a/app/src/main/java/de/lemke/oneurl/ui/QRBottomSheet.kt
+++ b/app/src/main/java/de/lemke/oneurl/ui/QRBottomSheet.kt
@@ -52,26 +52,6 @@ class QRBottomSheet : SemBottomSheetDialogFragment() {
             if (it.resultCode == RESULT_OK) requireContext().saveBitmapToUri(it.data?.data, qr)
         }
 
-    companion object {
-        const val KEY_TITLE = "key_title"
-        const val KEY_QR = "key_qr"
-        const val KEY_SAVE_LOCATION = "key_save_location"
-
-        fun createQRBottomSheet(
-            title: String,
-            qrCode: Bitmap,
-            saveLocation: SaveLocation,
-        ): QRBottomSheet =
-            QRBottomSheet().apply {
-                arguments =
-                    intentOf {
-                        +(KEY_TITLE to title)
-                        +(KEY_QR to qrCode.toByteArray())
-                        +(KEY_SAVE_LOCATION to saveLocation.toString())
-                    }.extras
-            }
-    }
-
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
         (super.onCreateDialog(savedInstanceState) as BottomSheetDialog).apply {
             behavior.skipCollapsed = true
@@ -102,6 +82,26 @@ class QRBottomSheet : SemBottomSheetDialogFragment() {
             binding.shareButton.setOnClickListener { shareBitmap(qrCode, "QRCode.png") }
             binding.saveButton.setOnClickListener { exportBitmap(saveLocation, qrCode, shortURL, exportQRCodeResultLauncher) }
         }
+    }
+
+    companion object {
+        const val KEY_TITLE = "key_title"
+        const val KEY_QR = "key_qr"
+        const val KEY_SAVE_LOCATION = "key_save_location"
+
+        fun createQRBottomSheet(
+            title: String,
+            qrCode: Bitmap,
+            saveLocation: SaveLocation,
+        ): QRBottomSheet =
+            QRBottomSheet().apply {
+                arguments =
+                    intentOf {
+                        +(KEY_TITLE to title)
+                        +(KEY_QR to qrCode.toByteArray())
+                        +(KEY_SAVE_LOCATION to saveLocation.toString())
+                    }.extras
+            }
     }
 }
 

--- a/app/src/main/java/de/lemke/oneurl/ui/URLActivity.kt
+++ b/app/src/main/java/de/lemke/oneurl/ui/URLActivity.kt
@@ -179,7 +179,7 @@ class URLActivity : AppCompatActivity() {
             .findItem(R.id.url_bnv_analytics)
             ?.isVisible = url.shortURLProvider.getAnalyticsURL(url.alias) != null
         binding.urlBnv.setOnItemSelectedListener { item -> handleBnvItemSelected(item, url) }
-        setCustomBackAnimation(binding.root, showInAppReviewIfPossible = true)
+        setCustomBackAnimation(binding.root, inAppReview = settings)
     }
 
     private fun handleBnvItemSelected(
@@ -247,8 +247,8 @@ class URLActivity : AppCompatActivity() {
             binding.urlVisitsRefreshButton.rotation = 0f
             binding.urlVisitsRefreshButton
                 .animate()
-                .rotationBy(-1080f)
-                .setDuration(2500)
+                .rotationBy(-REFRESH_SPIN_DEGREES)
+                .setDuration(REFRESH_SPIN_DURATION_MS)
                 .interpolator = AccelerateDecelerateInterpolator()
         }
     }
@@ -262,7 +262,7 @@ class URLActivity : AppCompatActivity() {
                 }
 
                 is UrlDetailEvent.Deleted -> {
-                    showInAppReviewOrFinish()
+                    showInAppReviewOrFinish(settings)
                 }
             }
         }
@@ -270,5 +270,7 @@ class URLActivity : AppCompatActivity() {
     companion object {
         const val KEY_SHORTURL = "key_shorturl"
         const val KEY_HIGHLIGHT_TEXT = "key_highlight_text"
+        private const val REFRESH_SPIN_DEGREES = 1080f
+        private const val REFRESH_SPIN_DURATION_MS = 2500L
     }
 }

--- a/app/src/main/java/de/lemke/oneurl/ui/URLActivity.kt
+++ b/app/src/main/java/de/lemke/oneurl/ui/URLActivity.kt
@@ -60,11 +60,6 @@ import dev.oneuiproject.oneui.design.R as designR
 
 @AndroidEntryPoint
 class URLActivity : AppCompatActivity() {
-    companion object {
-        const val KEY_SHORTURL = "key_shorturl"
-        const val KEY_HIGHLIGHT_TEXT = "key_highlight_text"
-    }
-
     @Inject
     lateinit var settings: SettingsRepository
 
@@ -271,4 +266,9 @@ class URLActivity : AppCompatActivity() {
                 }
             }
         }
+
+    companion object {
+        const val KEY_SHORTURL = "key_shorturl"
+        const val KEY_HIGHLIGHT_TEXT = "key_highlight_text"
+    }
 }

--- a/app/src/main/java/de/lemke/oneurl/ui/URLAdapter.kt
+++ b/app/src/main/java/de/lemke/oneurl/ui/URLAdapter.kt
@@ -48,10 +48,6 @@ class URLAdapter(
     ) {
     private val searchHighlighter = SearchHighlighter(context)
 
-    init {
-        setHasStableIds(true)
-    }
-
     private val asyncListDiffer =
         AsyncListDiffer(
             this,
@@ -74,11 +70,6 @@ class URLAdapter(
 
     var onLongClickItem: (() -> Unit)? = null
 
-    fun submitList(listItems: List<URL>) {
-        asyncListDiffer.submitList(listItems)
-        updateSelectableIds(listItems.map { it.id })
-    }
-
     var highlightWord = ""
         set(value) {
             if (value != field) {
@@ -89,7 +80,9 @@ class URLAdapter(
 
     private val currentList: List<URL> get() = asyncListDiffer.currentList
 
-    fun getItemByPosition(position: Int) = currentList[position]
+    init {
+        setHasStableIds(true)
+    }
 
     override fun getItemId(position: Int) = currentList[position].id
 
@@ -140,6 +133,13 @@ class URLAdapter(
         holder.bind(currentList[position])
         holder.bindActionMode(getItemId(position))
     }
+
+    fun submitList(listItems: List<URL>) {
+        asyncListDiffer.submitList(listItems)
+        updateSelectableIds(listItems.map { it.id })
+    }
+
+    fun getItemByPosition(position: Int) = currentList[position]
 
     inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         var selectableLayout: SelectableLinearLayout = itemView.findViewById(R.id.listItemSelectableLayout)

--- a/app/src/main/java/de/lemke/oneurl/ui/URLViewModel.kt
+++ b/app/src/main/java/de/lemke/oneurl/ui/URLViewModel.kt
@@ -51,10 +51,6 @@ class URLViewModel @Inject constructor(
     private val _events = Channel<UrlDetailEvent>(Channel.BUFFERED)
     val events: Flow<UrlDetailEvent> = _events.receiveAsFlow()
 
-    companion object {
-        private const val TAG = "URLViewModel"
-    }
-
     init {
         val shortURL = savedStateHandle.get<String>(KEY_SHORTURL) ?: ""
         viewModelScope.launch {
@@ -99,6 +95,10 @@ class URLViewModel @Inject constructor(
             deleteURL(url)
             _events.send(UrlDetailEvent.Deleted)
         }
+    }
+
+    companion object {
+        private const val TAG = "URLViewModel"
     }
 }
 

--- a/app/src/test/java/de/lemke/oneurl/CodingConventionsTest.kt
+++ b/app/src/test/java/de/lemke/oneurl/CodingConventionsTest.kt
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2023-2026 Leonard Lemke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.lemke.oneurl
+
+import com.lemonappdev.konsist.api.KoModifier
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
+import com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration
+import com.lemonappdev.konsist.api.declaration.KoInitBlockDeclaration
+import com.lemonappdev.konsist.api.declaration.KoInterfaceDeclaration
+import com.lemonappdev.konsist.api.declaration.KoObjectDeclaration
+import com.lemonappdev.konsist.api.declaration.KoPropertyDeclaration
+import com.lemonappdev.konsist.api.verify.assertTrue
+import io.kotest.core.spec.style.ShouldSpec
+
+class CodingConventionsTest : ShouldSpec() {
+    private val codeScope = Konsist.scopeFromProduction()
+
+    init {
+        should("properties declared before functions in class body") {
+            codeScope
+                .classes()
+                .assertTrue(testName = this.testCase.name.toString()) { koClass ->
+                    val declarations = koClass.declarations(includeNested = false, includeLocal = false)
+                    val lastPropertyIndex = declarations.indexOfLast { it is KoPropertyDeclaration }
+                    val firstFunctionIndex = declarations.indexOfFirst { it is KoFunctionDeclaration }
+                    lastPropertyIndex == -1 || firstFunctionIndex == -1 || lastPropertyIndex < firstFunctionIndex
+                }
+            codeScope
+                .interfaces()
+                .assertTrue(testName = this.testCase.name.toString()) { koInterface ->
+                    val declarations = koInterface.declarations(includeNested = false, includeLocal = false)
+                    val lastPropertyIndex = declarations.indexOfLast { it is KoPropertyDeclaration }
+                    val firstFunctionIndex = declarations.indexOfFirst { it is KoFunctionDeclaration }
+                    lastPropertyIndex == -1 || firstFunctionIndex == -1 || lastPropertyIndex < firstFunctionIndex
+                }
+        }
+        should("init blocks declared before functions in class body") {
+            codeScope
+                .classes()
+                .assertTrue(testName = this.testCase.name.toString()) { koClass ->
+                    val declarations = koClass.declarations(includeNested = false, includeLocal = false)
+                    val lastInitIndex = declarations.indexOfLast { it is KoInitBlockDeclaration }
+                    val firstFunctionIndex = declarations.indexOfFirst { it is KoFunctionDeclaration }
+                    lastInitIndex == -1 || firstFunctionIndex == -1 || lastInitIndex < firstFunctionIndex
+                }
+        }
+        should("override functions declared before non-override functions in class body") {
+            codeScope
+                .classes()
+                .assertTrue(testName = this.testCase.name.toString()) { koClass ->
+                    val functions = koClass.functions(includeNested = false, includeLocal = false)
+                    val lastOverrideIndex = functions.indexOfLast { it.hasModifier(KoModifier.OVERRIDE) }
+                    val firstNonOverrideIndex = functions.indexOfFirst { !it.hasModifier(KoModifier.OVERRIDE) }
+                    lastOverrideIndex == -1 || firstNonOverrideIndex == -1 || firstNonOverrideIndex > lastOverrideIndex
+                }
+            codeScope
+                .interfaces()
+                .assertTrue(testName = this.testCase.name.toString()) { koInterface ->
+                    val functions = koInterface.functions(includeNested = false, includeLocal = false)
+                    val lastOverrideIndex = functions.indexOfLast { it.hasModifier(KoModifier.OVERRIDE) }
+                    val firstNonOverrideIndex = functions.indexOfFirst { !it.hasModifier(KoModifier.OVERRIDE) }
+                    lastOverrideIndex == -1 || firstNonOverrideIndex == -1 || firstNonOverrideIndex > lastOverrideIndex
+                }
+        }
+        should("companion object is the last non-class member in class body") {
+            codeScope
+                .classes()
+                .assertTrue(testName = this.testCase.name.toString()) {
+                    val declarations = it.declarations(includeNested = false, includeLocal = false)
+                    val companion = it.objects(includeNested = false).lastOrNull { obj -> obj.hasModifier(KoModifier.COMPANION) }
+                    companion == null ||
+                        declarations.drop(declarations.indexOf(companion) + 1).none { decl ->
+                            decl is KoPropertyDeclaration || decl is KoFunctionDeclaration || decl is KoInitBlockDeclaration
+                        }
+                }
+            codeScope
+                .interfaces()
+                .assertTrue(testName = this.testCase.name.toString()) {
+                    val declarations = it.declarations(includeNested = false, includeLocal = false)
+                    val companion = it.objects(includeNested = false).lastOrNull { obj -> obj.hasModifier(KoModifier.COMPANION) }
+                    companion == null ||
+                        declarations.drop(declarations.indexOf(companion) + 1).none { decl ->
+                            decl is KoPropertyDeclaration || decl is KoFunctionDeclaration || decl is KoInitBlockDeclaration
+                        }
+                }
+        }
+        should("non-private nested class declarations are last in class body") {
+            codeScope
+                .classes()
+                .assertTrue(testName = this.testCase.name.toString()) {
+                    val declarations = it.declarations(includeNested = false, includeLocal = false)
+                    val firstNonPrivateClassTypeIndex =
+                        declarations.indexOfFirst { decl ->
+                            when (decl) {
+                                is KoClassDeclaration -> !decl.hasModifier(KoModifier.PRIVATE)
+                                is KoInterfaceDeclaration -> !decl.hasModifier(KoModifier.PRIVATE)
+                                is KoObjectDeclaration -> !decl.hasModifier(KoModifier.COMPANION) && !decl.hasModifier(KoModifier.PRIVATE)
+                                else -> false
+                            }
+                        }
+                    val lastNonClassTypeIndex =
+                        declarations.indexOfLast { decl ->
+                            decl is KoPropertyDeclaration || decl is KoFunctionDeclaration ||
+                                decl is KoInitBlockDeclaration ||
+                                (decl is KoObjectDeclaration && decl.hasModifier(KoModifier.COMPANION))
+                        }
+                    firstNonPrivateClassTypeIndex == -1 || lastNonClassTypeIndex == -1 ||
+                        firstNonPrivateClassTypeIndex > lastNonClassTypeIndex
+                }
+            codeScope
+                .interfaces()
+                .assertTrue(testName = this.testCase.name.toString()) {
+                    val declarations = it.declarations(includeNested = false, includeLocal = false)
+                    val firstNonPrivateClassTypeIndex =
+                        declarations.indexOfFirst { decl ->
+                            when (decl) {
+                                is KoClassDeclaration -> !decl.hasModifier(KoModifier.PRIVATE)
+                                is KoInterfaceDeclaration -> !decl.hasModifier(KoModifier.PRIVATE)
+                                is KoObjectDeclaration -> !decl.hasModifier(KoModifier.COMPANION) && !decl.hasModifier(KoModifier.PRIVATE)
+                                else -> false
+                            }
+                        }
+                    val lastNonClassTypeIndex =
+                        declarations.indexOfLast { decl ->
+                            decl is KoPropertyDeclaration || decl is KoFunctionDeclaration ||
+                                decl is KoInitBlockDeclaration ||
+                                (decl is KoObjectDeclaration && decl.hasModifier(KoModifier.COMPANION))
+                        }
+                    firstNonPrivateClassTypeIndex == -1 || lastNonClassTypeIndex == -1 ||
+                        firstNonPrivateClassTypeIndex > lastNonClassTypeIndex
+                }
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,6 +70,8 @@ fun getProperty(key: String): String =
 val githubUsername = getProperty("ghUsername")
 val githubAccessToken = getProperty("ghAccessToken")
 
+val checkDependencyUpdates = providers.gradleProperty("lint.checkDependencyUpdates").getOrElse("true").toBoolean()
+
 allprojects {
     repositories {
         google()
@@ -107,6 +109,13 @@ subprojects {
                 sourceCompatibility = JavaVersion.VERSION_21
                 targetCompatibility = JavaVersion.VERSION_21
             }
+
+            // Renovate owns dependency freshness on its own PRs; enforcing there would fail every
+            // in-flight bump against every other still-pending one.
+            if (!checkDependencyUpdates) {
+                lint.informational += setOf("GradleDependency", "NewerVersionAvailable")
+            }
+
             // oneui-design replaces these AOSP AndroidX modules with Samsung's SESL forks, which
             // keep the original package names — exclude the AOSP originals everywhere to prevent
             // shadowing. androidTest specifically needs SESL: instrumented tests launch SESL

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -34,7 +34,10 @@ complexity:
 style:
   active: true
   MagicNumber:
-    active: false
+    active: true
+    ignoreNumbers: [ '-1', '0', '1', '2', '0.5' ]
+    ignorePropertyDeclaration: true
+    ignoreCompanionObjectPropertyDeclaration: true
   MaxLineLength:
     maxLineLength: 140
   ForbiddenComment:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ hilt = "2.60.1"
 junit-jupiter = "6.1.3"
 junit-platform = "6.1.3"
 konsist = "0.17.3"
+kotest = "6.2.4"
 kotlin = "2.4.10"
 ksp = "2.3.11"
 # Used via spotless { kotlin { ktlint(libs.versions.ktlint.get()) } } — version-only ref, no library/plugin alias
@@ -31,6 +32,7 @@ junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.re
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit-jupiter" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }
 konsist = { module = "com.lemonappdev:konsist", version.ref = "konsist" }
+kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 leakcanary = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakcanary" }
 oneui-design = { module = "io.github.tribalfs:oneui-design", version.ref = "oneui-design" }
 oneui-icons = { module = "io.github.oneuiproject:icons", version.ref = "oneui-icons" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ jvmTarget = "21"
 
 aboutlibraries = "15.2.0"
 bundler = "1.0.4"
-commonUtils = "1.2.3"
+commonUtils = "1.2.5"
 dependency-analysis = "3.19.1"
 detekt = "2.0.0-alpha.6"
 gradle = "9.4.0"
@@ -14,7 +14,7 @@ junit-jupiter = "6.1.3"
 junit-platform = "6.1.3"
 konsist = "0.17.3"
 kotest = "6.2.4"
-kotlin = "2.4.10"
+kotlin = "2.4.20"
 ksp = "2.3.11"
 # Used via spotless { kotlin { ktlint(libs.versions.ktlint.get()) } } — version-only ref, no library/plugin alias
 #noinspection UnusedVersionCatalogEntry


### PR DESCRIPTION
## Summary
- Add Konsist `CodingConventionsTest.kt` (ported from GetIcon), conform source to its declaration-ordering rules
- Flip Detekt `MagicNumber` to `active: true`, extract flagged literals to named constants (shared `HttpStatusCode` object for repeated HTTP status codes across provider implementations)
- Exempt Renovate PRs from `GradleDependency`/`NewerVersionAvailable` lint checks so its one-PR-per-update model doesn't deadlock

## Test plan
- [x] `./gradlew spotlessCheck detekt lintDebug test assembleDebug` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added Konsist coding-convention checks and fixed declaration ordering.
- Enabled Detekt `MagicNumber` checks and replaced literals with named constants.
- Centralized HTTP status codes and extracted error-handling helpers.
- Updated Kotlin, `common-utils`, and Kotest dependencies.
- Exempted Renovate PRs from dependency-update lint checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->